### PR TITLE
Fix legacy warning spelling

### DIFF
--- a/_includes/legacy-warning.html
+++ b/_includes/legacy-warning.html
@@ -5,7 +5,7 @@
 {% if post_time < reference_time %}
   <div class="alert alert-light" role="alert">
     This REP was produced using the old process, described in <a href="/rep-0001/">REP-0001:2012</a>. It remains active
-    and the content is still useful and in use today. However, if there's a need for udpating this REP please following
+    and the content is still useful and in use today. However, if there's a need for updating this REP, please follow
     the new process, described in <a href="/rep-0001-2025/">REP-0001:2025</a>, to bring it in line with our current-day
     standards and incorporate new knowledge that has become available since it was originally produced.
   </div>


### PR DESCRIPTION
There was a minor spelling mistake in the legacy REP header.